### PR TITLE
Add diagnostic logging to debug secrets issue.

### DIFF
--- a/ammo_trading_agent/config.py
+++ b/ammo_trading_agent/config.py
@@ -26,6 +26,19 @@ class Config:
             self._initialized = True
             logger.info("Initializing configuration...")
 
+            # --- DIAGNOSTIC LOGGING ---
+            if hasattr(st, 'secrets'):
+                logger.info("--- DIAGNOSTICS: st.secrets is available ---")
+                try:
+                    # Log all top-level keys to understand the structure
+                    logger.info(f"Available keys in st.secrets: {st.secrets.keys()}")
+                except Exception as e:
+                    logger.error(f"Error during diagnostic logging of st.secrets: {e}")
+                logger.info("--- END DIAGNOSTICS ---")
+            else:
+                logger.info("--- DIAGNOSTICS: st.secrets is NOT available ---")
+            # --- END DIAGNOSTIC LOGGING ---
+
             # Load .env file for local development
             self._load_dotenv()
 


### PR DESCRIPTION
This commit adds temporary logging to the `Config` class to inspect the structure of the `st.secrets` object in the user's environment. This is intended to diagnose why the API keys are not being read correctly, even when present in the secrets file.

The logs will show the top-level keys available in `st.secrets`, which will help determine if the keys are nested under a section header.