### PR TITLE
feat: Integrate Finnhub and add interactive API key inputs

### DIFF
--- a/ammo_trading_agent/config.py
+++ b/ammo_trading_agent/config.py
@@ -1,93 +1,41 @@
 # config.py
 
-import os
-import streamlit as st
-from dotenv import load_dotenv
 from utils.helpers import setup_logging
 
 logger = setup_logging()
 
 class Config:
     """
-    A centralized configuration class to manage settings and API keys.
-    This class defers the loading of secrets until it is instantiated,
-    preventing import-time errors in Streamlit Cloud.
+    A simple configuration class to hold API keys and settings provided by the user at runtime.
     """
-    _instance = None
-
-    def __new__(cls, *args, **kwargs):
-        if not cls._instance:
-            cls._instance = super(Config, cls).__new__(cls)
-        return cls._instance
-
-    def __init__(self):
-        # This check ensures that the initialization logic runs only once
-        if not hasattr(self, '_initialized'):
-            self._initialized = True
-            logger.info("Initializing configuration...")
-
-            # --- DIAGNOSTIC LOGGING ---
-            if hasattr(st, 'secrets'):
-                logger.info("--- DIAGNOSTICS: st.secrets is available ---")
-                try:
-                    # Log all top-level keys to understand the structure
-                    logger.info(f"Available keys in st.secrets: {st.secrets.keys()}")
-                except Exception as e:
-                    logger.error(f"Error during diagnostic logging of st.secrets: {e}")
-                logger.info("--- END DIAGNOSTICS ---")
-            else:
-                logger.info("--- DIAGNOSTICS: st.secrets is NOT available ---")
-            # --- END DIAGNOSTIC LOGGING ---
-
-            # Load .env file for local development
-            self._load_dotenv()
-
-            # --- API Keys ---
-            self.ALPHA_VANTAGE_API_KEY = self._get_secret("ALPHA_VANTAGE_API_KEY")
-            self.NEWS_API_KEY = self._get_secret("NEWS_API_KEY")
-            self.ALPACA_API_KEY = self._get_secret("ALPACA_API_KEY")
-            self.ALPACA_SECRET_KEY = self._get_secret("ALPACA_SECRET_KEY")
-            self.ALPACA_BASE_URL = self._get_secret("ALPACA_BASE_URL") or "https://paper-api.alpaca.markets"
-
-            # --- Application Settings ---
-            self.APP_TITLE = "AMMO Trading Agent"
-
-            # Log the operating mode
-            if self.is_simulation_mode():
-                logger.warning("Application is running in SIMULATION MODE.")
-            else:
-                logger.info("All API keys are configured. Application is in LIVE MODE.")
-
-    def _load_dotenv(self):
-        """Loads environment variables from a .env file if it exists."""
-        dotenv_path = os.path.join(os.path.dirname(__file__), '.env')
-        if os.path.exists(dotenv_path):
-            load_dotenv(dotenv_path)
-            logger.info(".env file found and loaded for local development.")
-
-    def _get_secret(self, secret_name: str) -> str:
+    def __init__(self, finnhub_api_key: str = None, news_api_key: str = None):
         """
-        Fetches a secret from Streamlit's secrets manager with a fallback to environment variables.
-        """
-        try:
-            # Prefer Streamlit's secrets manager
-            if hasattr(st, 'secrets') and secret_name in st.secrets:
-                return st.secrets[secret_name]
-        except Exception:
-            logger.warning(f"Could not access Streamlit secrets for '{secret_name}'. Falling back to environment variables.")
+        Initializes the config with the provided API keys.
 
-        # Fallback to environment variable
-        return os.getenv(secret_name)
+        Args:
+            finnhub_api_key (str, optional): The API key for Finnhub. Defaults to None.
+            news_api_key (str, optional): The API key for NewsAPI. Defaults to None.
+        """
+        logger.info("Initializing configuration with user-provided keys...")
+
+        # --- API Keys ---
+        self.FINNHUB_API_KEY = finnhub_api_key
+        self.NEWS_API_KEY = news_api_key
+
+        # --- Application Settings ---
+        self.APP_TITLE = "AMMO Trading Agent"
+
+        # Log the operating mode
+        if self.is_simulation_mode():
+            logger.warning("Running in simulation mode due to one or more missing API keys.")
+        else:
+            logger.info("All necessary API keys are configured. Running in live mode.")
 
     def is_simulation_mode(self) -> bool:
         """
         Checks if the application should run in simulation mode due to missing API keys.
         """
-        if not self.ALPHA_VANTAGE_API_KEY or self.ALPHA_VANTAGE_API_KEY == "YOUR_ALPHA_VANTAGE_API_KEY":
-            return True
-        if not self.NEWS_API_KEY or self.NEWS_API_KEY == "YOUR_NEWS_API_KEY":
+        # Simulation mode is active if any of the essential keys are missing.
+        if not self.FINNHUB_API_KEY or not self.NEWS_API_KEY:
             return True
         return False
-
-# The Config class should be instantiated at runtime in the main app,
-# not at import time.

--- a/ammo_trading_agent/requirements.txt
+++ b/ammo_trading_agent/requirements.txt
@@ -3,6 +3,7 @@ streamlit
 pandas
 numpy
 requests
+finnhub-python
 
 # For data visualization (optional but recommended)
 plotly


### PR DESCRIPTION
This commit implements two major user-requested features:
1.  Replaces Alpha Vantage with Finnhub as the primary data provider.
2.  Removes all backend secret-loading logic (`st.secrets`, `.env`) in favor of interactive API key input fields in the Streamlit UI.

Key changes:
- The UI in `app.py` has been updated to include password-masked input fields for the Finnhub and NewsAPI keys. The "Analyze Market" button is disabled until both keys are provided.
- `data_collector.py` has been completely rewritten to use the `finnhub-python` library to fetch and process market data.
- `requirements.txt` has been updated to include `finnhub-python`.
- `config.py` has been simplified to a basic container that holds the API keys provided by the user at runtime.
- The application logic has been updated to instantiate the `Config` and `AmmoAgent` with the user-provided keys from the UI.