### PR TITLE
fix: Remove aggressive Finnhub API key validation and improve error h…

### DIFF
--- a/ammo_trading_agent/ammo_agent.py
+++ b/ammo_trading_agent/ammo_agent.py
@@ -39,11 +39,15 @@ class AmmoAgent:
         logger.info(f"--- Starting {time_frame} Analysis for {symbol} ---")
 
         # 1. Collect Data
-        price_data = self.data_collector.get_price_data(symbol, time_frame, output_size="compact")
+        price_data, error_message = self.data_collector.get_price_data(symbol, time_frame, output_size="compact")
+        if error_message:
+            logger.error(f"Data collection failed for {symbol} ({time_frame}): {error_message}")
+            return {"error": error_message}
+
         if price_data.empty:
-            logger.error(f"Failed to collect data for {symbol} ({time_frame}). Aborting analysis.")
+            logger.error(f"Data collection for {symbol} ({time_frame}) returned an empty DataFrame without an error message.")
             return {
-                "error": f"Could not retrieve {time_frame} price data for {symbol}. The symbol may be invalid or the API may be unavailable."
+                "error": f"Could not retrieve {time_frame} price data for {symbol}. The symbol may be invalid or the API returned no data."
             }
 
         latest_price = price_data['close'].iloc[-1]


### PR DESCRIPTION
…andling

This commit resolves a bug where the application would incorrectly invalidate a user's Finnhub API key. The previous implementation used a test API call (`company_profile2`) that is not available on all key types, causing the application to fail even with a valid key for fetching price data.

This commit also improves the error handling to provide more specific feedback to the user in the UI if data collection fails.

Key changes:
- Removed the aggressive API key validation from `data_collector.py`'s `__init__` method. The client is now initialized without a test call.
- The `get_price_data` method in `data_collector.py` now returns a tuple `(data, error_message)` to provide more specific error details.
- `ammo_agent.py` has been updated to consume and display the new, more informative error message in the UI.
- The `sentiment_analyzer.py` has been refactored to align with the latest configuration and error handling patterns.