### PR TITLE
feat: Add interactive API key inputs and revert to Alpha Vantage

### DIFF
--- a/ammo_trading_agent/app.py
+++ b/ammo_trading_agent/app.py
@@ -44,10 +44,10 @@ st.markdown("Enter your API keys below to connect to live data sources.")
 
 col1, col2 = st.columns(2)
 with col1:
-    finnhub_api_key = st.text_input(
-        "Finnhub API Key",
+    alpha_vantage_key = st.text_input(
+        "Alpha Vantage API Key",
         type="password",
-        help="Get a free key from [Finnhub](https://finnhub.io/register)"
+        help="Get a free key from [Alpha Vantage](https://www.alphavantage.co/support/#api-key)"
     )
 with col2:
     news_api_key = st.text_input(
@@ -57,12 +57,12 @@ with col2:
     )
 
 # Store keys in session state to persist them
-if finnhub_api_key:
-    st.session_state.finnhub_api_key = finnhub_api_key
+if alpha_vantage_key:
+    st.session_state.alpha_vantage_key = alpha_vantage_key
 if news_api_key:
     st.session_state.news_api_key = news_api_key
 
-keys_provided = hasattr(st.session_state, 'finnhub_api_key') and hasattr(st.session_state, 'news_api_key')
+keys_provided = hasattr(st.session_state, 'alpha_vantage_key') and hasattr(st.session_state, 'news_api_key')
 
 # --- Sidebar for User Inputs ---
 with st.sidebar:
@@ -90,7 +90,7 @@ if "results" not in st.session_state:
 if analyze_button:
     # When the button is clicked, create a config object with the user-provided keys
     config = Config(
-        finnhub_api_key=st.session_state.get('finnhub_api_key'),
+        alpha_vantage_api_key=st.session_state.get('alpha_vantage_key'),
         news_api_key=st.session_state.get('news_api_key')
     )
 

--- a/ammo_trading_agent/config.py
+++ b/ammo_trading_agent/config.py
@@ -8,18 +8,18 @@ class Config:
     """
     A simple configuration class to hold API keys and settings provided by the user at runtime.
     """
-    def __init__(self, finnhub_api_key: str = None, news_api_key: str = None):
+    def __init__(self, alpha_vantage_api_key: str = None, news_api_key: str = None):
         """
         Initializes the config with the provided API keys.
 
         Args:
-            finnhub_api_key (str, optional): The API key for Finnhub. Defaults to None.
+            alpha_vantage_api_key (str, optional): The API key for Alpha Vantage. Defaults to None.
             news_api_key (str, optional): The API key for NewsAPI. Defaults to None.
         """
         logger.info("Initializing configuration with user-provided keys...")
 
         # --- API Keys ---
-        self.FINNHUB_API_KEY = finnhub_api_key
+        self.ALPHA_VANTAGE_API_KEY = alpha_vantage_api_key
         self.NEWS_API_KEY = news_api_key
 
         # --- Application Settings ---
@@ -36,6 +36,6 @@ class Config:
         Checks if the application should run in simulation mode due to missing API keys.
         """
         # Simulation mode is active if any of the essential keys are missing.
-        if not self.FINNHUB_API_KEY or not self.NEWS_API_KEY:
+        if not self.ALPHA_VANTAGE_API_KEY or not self.NEWS_API_KEY:
             return True
         return False

--- a/ammo_trading_agent/modules/data_collector.py
+++ b/ammo_trading_agent/modules/data_collector.py
@@ -2,15 +2,14 @@
 
 import pandas as pd
 import numpy as np
-import finnhub
-from datetime import datetime, timedelta
+import requests
 from utils.helpers import setup_logging
 
 logger = setup_logging()
 
 class DataCollector:
     """
-    Collects market data using the Finnhub API.
+    Collects market data using the Alpha Vantage API.
     """
 
     def __init__(self, config):
@@ -21,73 +20,99 @@ class DataCollector:
             config: The configuration object containing API keys.
         """
         self.config = config
-        self.api_key = self.config.FINNHUB_API_KEY
-        self.finnhub_client = None
+        self.api_key = self.config.ALPHA_VANTAGE_API_KEY
+        self.base_url = "https://www.alphavantage.co/query"
         if not self.config.is_simulation_mode():
-            self.finnhub_client = finnhub.Client(api_key=self.api_key)
-            logger.info("Finnhub client initialized.")
+            logger.info("DataCollector initialized for Alpha Vantage.")
         else:
             logger.warning("DataCollector is in simulation mode due to missing API keys.")
 
     def get_price_data(self, symbol: str, time_frame: str, output_size: str = "compact") -> tuple[pd.DataFrame, str | None]:
         """
-        Fetches historical stock prices for a given symbol using the Finnhub API.
-
-        Args:
-            symbol (str): The stock symbol (e.g., "AAPL").
-            time_frame (str): "Daily", "Weekly", or "Intraday (60min)".
-            output_size (str): Kept for compatibility, not directly used by Finnhub.
+        Fetches historical stock prices from Alpha Vantage.
 
         Returns:
             A tuple containing:
                 - pd.DataFrame: A DataFrame with historical price data, or an empty DataFrame on error.
                 - str | None: An error message string if an error occurred, otherwise None.
         """
-        if self.config.is_simulation_mode() or self.finnhub_client is None:
-            df, err = self._get_simulated_data(symbol, time_frame)
-            return df, err
+        if self.config.is_simulation_mode():
+            return self._get_simulated_data(symbol, time_frame)
 
-        resolution_map = {"Daily": "D", "Weekly": "W", "Intraday (60min)": "60"}
-        resolution = resolution_map.get(time_frame)
-        if not resolution:
+        # Map our time frames to Alpha Vantage API parameters
+        time_frame_map = {
+            "Daily": {"function": "TIME_SERIES_DAILY_ADJUSTED", "key": "Time Series (Daily)"},
+            "Weekly": {"function": "TIME_SERIES_WEEKLY_ADJUSTED", "key": "Weekly Adjusted Time Series"},
+            "Intraday (60min)": {"function": "TIME_SERIES_INTRADAY", "key": "Time Series (60min)", "interval": "60min"},
+        }
+
+        if time_frame not in time_frame_map:
             msg = f"Invalid time frame specified: {time_frame}"
             logger.error(msg)
             return pd.DataFrame(), msg
 
-        to_date = datetime.now()
-        from_date = to_date - timedelta(days=30 if time_frame == "Intraday (60min)" else 365)
-        from_unix, to_unix = int(from_date.timestamp()), int(to_date.timestamp())
+        api_params = time_frame_map[time_frame]
+        params = {
+            "function": api_params["function"],
+            "symbol": symbol,
+            "outputsize": output_size,
+            "apikey": self.api_key,
+        }
+        if "interval" in api_params:
+            params["interval"] = api_params["interval"]
 
         try:
-            logger.info(f"Fetching {time_frame} data for {symbol} from Finnhub...")
-            res = self.finnhub_client.stock_candles(symbol, resolution, from_unix, to_unix)
+            logger.info(f"Fetching {time_frame} data for {symbol} from Alpha Vantage...")
+            response = requests.get(self.base_url, params=params)
+            response.raise_for_status()
+            data = response.json()
 
-            if res.get('s') != 'ok' or not res.get('c'):
-                error_msg = f"Finnhub API returned no data for {symbol}. This could be due to an invalid symbol or an API key with insufficient permissions for this data."
-                logger.error(f"Finnhub error for {symbol}: {res}")
+            # Check for specific Alpha Vantage API error messages
+            if "Error Message" in data:
+                error_msg = f"Alpha Vantage API error for {symbol}: {data['Error Message']}"
+                logger.error(error_msg)
+                return pd.DataFrame(), error_msg
+            if "Note" in data:
+                error_msg = f"Alpha Vantage API Note for {symbol}: {data['Note']}. This might mean you've exceeded the API call frequency. Please wait a minute and try again."
+                logger.error(error_msg)
                 return pd.DataFrame(), error_msg
 
-            df = pd.DataFrame(res)
-            df.rename(columns={'o': 'open', 'h': 'high', 'l': 'low', 'c': 'close', 'v': 'volume', 't': 'time'}, inplace=True)
-            df['time'] = pd.to_datetime(df['time'], unit='s')
-            df.set_index('time', inplace=True)
-            df.drop('s', axis=1, inplace=True)
+            data_key = api_params["key"]
+            if data_key not in data:
+                error_msg = f"Could not find data key '{data_key}' in the Alpha Vantage response for {symbol}. The symbol may be invalid."
+                logger.error(f"{error_msg} Full response: {data}")
+                return pd.DataFrame(), error_msg
+
+            df = pd.DataFrame.from_dict(data[data_key], orient="index")
+
+            # Standardize column names
+            rename_map = {
+                "1. open": "open", "2. high": "high", "3. low": "low", "4. close": "close",
+                "5. adjusted close": "adjusted_close", "6. volume": "volume"
+            }
+            intraday_rename_map = {
+                "1. open": "open", "2. high": "high", "3. low": "low", "4. close": "close", "5. volume": "volume"
+            }
+            df.rename(columns=intraday_rename_map if time_frame == "Intraday (60min)" else rename_map, inplace=True)
+
+            df.index = pd.to_datetime(df.index)
+            df = df.astype(float).sort_index()
 
             logger.info(f"Successfully fetched {len(df)} data points for {symbol}.")
-            return df.astype(float), None
+            return df, None
 
-        except finnhub.FinnhubAPIException as e:
-            error_msg = f"Finnhub API error for {symbol}: {e}. Please check if the symbol is correct and your API key is valid."
+        except requests.exceptions.RequestException as e:
+            error_msg = f"A network error occurred while fetching data from Alpha Vantage for {symbol}: {e}"
             logger.error(error_msg)
             return pd.DataFrame(), error_msg
-        except Exception as e:
-            error_msg = f"An unexpected error occurred while fetching data from Finnhub for {symbol}: {e}"
-            logger.error(error_msg)
+        except (ValueError, KeyError) as e:
+            error_msg = f"An error occurred while processing data from Alpha Vantage for {symbol}: {e}"
+            logger.error(f"{error_msg}. API Response: {data}")
             return pd.DataFrame(), error_msg
 
     def _get_simulated_data(self, symbol: str, time_frame: str) -> tuple[pd.DataFrame, str | None]:
         """
-        Generates fake market data and matches the return signature of get_price_data.
+        Generates fake market data for demonstration purposes.
         """
         logger.info(f"Generating simulated {time_frame} data for {symbol}.")
         dates = pd.to_datetime(pd.date_range(end=pd.Timestamp.today(), periods=100))

--- a/ammo_trading_agent/requirements.txt
+++ b/ammo_trading_agent/requirements.txt
@@ -3,7 +3,6 @@ streamlit
 pandas
 numpy
 requests
-finnhub-python
 
 # For data visualization (optional but recommended)
 plotly


### PR DESCRIPTION
This commit implements a major refactoring of the application to address persistent user issues with API key configuration and data provider access. The application now uses a fully interactive system for API key management and has reverted to Alpha Vantage as the primary data provider.

Key changes:
- The UI in `app.py` has been updated to include password-masked input fields for the Alpha Vantage and NewsAPI keys. The 'Analyze Market' button is now disabled until both keys are provided.
- `data_collector.py` has been rewritten to use the `requests` library to fetch data from Alpha Vantage, using the user-provided key.
- The `finnhub-python` dependency has been removed from `requirements.txt`.
- `config.py` has been simplified to a basic container that holds the API keys provided by the user at runtime.
- The application logic has been updated to instantiate the `Config` and `AmmoAgent` with the user-provided keys from the UI.